### PR TITLE
Remove the div#router tag

### DIFF
--- a/lib/mount.js
+++ b/lib/mount.js
@@ -5,6 +5,7 @@ const {
 } = require('tinyfunk')
 
 const combine  = require('./combine')
+const fullPath = require('./fullPath')
 const init     = require('./init')
 const route    = require('./route')
 const throttle = require('./throttle')
@@ -23,22 +24,24 @@ const mount = opts => {
     view
   } = opts
 
-  let router
+  let onpopstate = identity
+  let unsub      = identity
+  let up         = true
+
+  const dispatch = axn => up && flow(axn)
 
   if (routes) {
-    router   = route(routes)
-    actions  = merge(actions, router.actions)
-    reducers = merge(reducers, router.reducers)
-    view     = router.view
+    const router = route(routes)
+    actions      = merge(actions, router.actions)
+    onpopstate   = compose(dispatch, actions.route.back, fullPath)
+    reducers     = merge(reducers, router.reducers)
+    view         = router.view
+    addEventListener('popstate', onpopstate)
   }
 
   const reducer = combine(reducers)
 
   let state = reducer(void 0, {})
-  let unsub = identity
-  let up    = true
-
-  const dispatch = axn => up && flow(axn)
 
   const getState = () => state
 
@@ -78,7 +81,7 @@ const mount = opts => {
 
   const teardown = () => {
     patch(root, h('div'))
-    router && router.teardown()
+    removeEventListener('popstate', onpopstate)
     unsub()
     up = false
   }

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,8 +1,6 @@
 const h = require('snabbdom/h').default
 
-const {
-  compose, constant, curry, identity, match, replace, zipObj
-} = require('tinyfunk')
+const { curry, match, replace, zipObj } = require('tinyfunk')
 
 const action   = require('./action')
 const fullPath = require('./fullPath')
@@ -37,13 +35,6 @@ const pathToRegexp = pattern =>
 
 // route : Object -> Object
 const route = routes => {
-  let onpopstate = identity
-
-  const attach = constant(dispatch => {
-    onpopstate = compose(dispatch, back, fullPath)
-    addEventListener('popstate', onpopstate)
-  })
-
   const init = matchRoute(routes, {}, fullPath())
 
   const reducer = handle(init, {
@@ -51,25 +42,18 @@ const route = routes => {
     [ GO   ]: navigate(routes)
   })
 
-  const teardown = () =>
-    removeEventListener('popstate', onpopstate)
-
   return {
-    actions: { route: { attach, back, go } },
+    actions: { route: { back, go } },
     reducers: { route: reducer },
-    teardown,
     view: view(routes)
   }
 }
 
 const view = curry((routes, actions, state) => {
-  const { route: { attach } }  = actions
   const { route: { pattern } } = state
 
   return h('div#root', [
-    h('div#router', { hook: { create: attach } }, [
-      pattern ? routes[pattern](actions, state) : ''
-    ])
+    pattern ? routes[pattern](actions, state) : ''
   ])
 })
 


### PR DESCRIPTION
![routing problems](http://4.bp.blogspot.com/-WMOmPhEM39I/T64bWI3k1JI/AAAAAAAAAQ0/wdA1DuGF2Bw/s1600/techsupport.gif)

Back in `v1`, I needed an extra `div#router` tag just to use the `create` hook for attaching to the `'hashchange'` event.  I sorta let that carry over into `v2`, but with the hand-crafted Redux flow, that technique is really no longer necessary.  So this PR removes it.